### PR TITLE
Update trading strategy for index funds

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -16,6 +16,7 @@ class TestMCPClient(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {'result': 'ok'}
         mock_response.raise_for_status.return_value = None
+        mock_response.status_code = 200
         mock_post.return_value = mock_response
         client = MCPClient('http://fake-url')
         result = client.send('PROMPT')
@@ -25,8 +26,8 @@ class TestMCPClient(unittest.TestCase):
     def test_send_failure(self, mock_post):
         mock_post.side_effect = Exception('fail')
         client = MCPClient('http://fake-url')
-        result = client.send('PROMPT')
-        self.assertEqual(result, '')
+        with self.assertRaises(Exception):
+            client.send('PROMPT')
 
 if __name__ == '__main__':
     unittest.main() 

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -6,10 +6,22 @@ sys.path.insert(0, os.path.abspath('..'))
 from agents.trading_agent import SmartM1TradingAgent
 
 class TestSmartM1TradingAgent(unittest.TestCase):
+    @patch('agents.trading_agent.FinBertSentiment')
+    @patch('agents.trading_agent.SmartM1TradingAgent.get_top_movers')
+    @patch('agents.trading_agent.SmartM1TradingAgent.fetch_news_sentiment_batch')
     @patch('agents.trading_agent.MCPClient')
-    def test_generate_portfolio_with_llm(self, MockMCPClient):
+    def test_generate_portfolio_with_llm(self, MockMCPClient, mock_news, mock_movers, MockFinBert):
         mock_mcp = MockMCPClient.return_value
-        mock_mcp.send.return_value = '{"AAPL": 0.6, "MSFT": 0.4}'
+        mock_mcp.send.side_effect = [
+            '{"funds": ["SPY"]}',
+            '{"AAPL": 0.6, "MSFT": 0.4}'
+        ]
+        mock_movers.return_value = (["AAPL"], ["MSFT"])
+        mock_news.return_value = {
+            "AAPL": (["h1"], 1.1),
+            "MSFT": (["h2"], 1.1)
+        }
+        MockFinBert.return_value.aggregate_score.return_value = {"positive":1.0,"negative":0.0,"neutral":0.0}
         agent = SmartM1TradingAgent(api_key='dummy')
         agent.generate_portfolio_with_llm()
         self.assertEqual(agent.portfolio, {"AAPL": 0.6, "MSFT": 0.4})

--- a/tests/test_verification_agent.py
+++ b/tests/test_verification_agent.py
@@ -10,8 +10,24 @@ class TestTradeVerificationAgent(unittest.TestCase):
     def test_format_email_body(self, MockMCPClient):
         agent = TradeVerificationAgent()
         trades = [
-            {"symbol": "AAPL", "amount": 500, "time": "2024-06-01T12:00:00"},
-            {"symbol": "MSFT", "amount": 500, "time": "2024-06-01T12:00:00"}
+            {
+                "transaction_id": "1",
+                "symbol": "AAPL",
+                "amount": 500,
+                "allocation": 0.5,
+                "current_price": 100.0,
+                "time": "12:00:00",
+                "date": "2024-06-01",
+            },
+            {
+                "transaction_id": "1",
+                "symbol": "MSFT",
+                "amount": 500,
+                "allocation": 0.5,
+                "current_price": 200.0,
+                "time": "12:00:00",
+                "date": "2024-06-01",
+            },
         ]
         body = agent.format_email_body(trades)
         self.assertIn("AAPL", body)


### PR DESCRIPTION
## Summary
- implement index-fund strategy in `SmartM1TradingAgent`
- fetch batch news sentiment and analyze top movers
- adjust unit tests for new behaviour
- fix MCP client tests
- fix verification agent test samples

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871989c1658832d99ca05fc230d4f4c